### PR TITLE
Fix invalid max_emails crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This server is designed to be used with an MCP client. It communicates over stan
   "properties": {
     "max_emails": {
       "type": "number",
-      "description": "Maximum number of unread emails to fetch",
+      "description": "Maximum number of unread emails to fetch. Must be a non-negative integer.",
       "optional": true
     }
   }

--- a/gmail_mcp_server.py
+++ b/gmail_mcp_server.py
@@ -73,6 +73,20 @@ def handle_get_unread_emails(request_id, arguments):
     gmail_email = os.environ.get('GMAIL_EMAIL')
     gmail_app_password = os.environ.get('GMAIL_APP_PASSWORD')
     max_emails = arguments.get('max_emails')
+    if max_emails is not None:
+        try:
+            max_emails = int(max_emails)
+            if max_emails < 0:
+                raise ValueError
+        except (ValueError, TypeError):
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {
+                    "content": [{"type": "text", "text": "Invalid 'max_emails' value."}],
+                    "isError": True
+                }
+            }
 
     if not gmail_email or not gmail_app_password:
         return {


### PR DESCRIPTION
## Summary
- validate the `max_emails` argument in `get_unread_emails`
- document that `max_emails` must be a non-negative integer

## Testing
- `python3 gmail_mcp_server.py <<'EOF'
{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "get_unread_emails", "arguments": {"max_emails": "foo"}}}
EOF`
- `pyflakes gmail_mcp_server.py`
- `pylint gmail_mcp_server.py`
- `python3 -m py_compile gmail_mcp_server.py`

------
https://chatgpt.com/codex/tasks/task_e_686bbbc3c8b88325af6760ceab78e566