### PR TITLE
Update sample settings email placeholder

### DIFF
--- a/cline_mcp_settings.json.sample
+++ b/cline_mcp_settings.json.sample
@@ -7,7 +7,7 @@
       "command": "~/Documents/Cline/MCP/gmail-mcp-server/gmail_mcp_server.py",
       "args": [],
       "env": {
-        "GMAIL_EMAIL": "<YOUR EMAIL>",
+        "GMAIL_EMAIL": "<YOUR_GMAIL_ADDRESS>",
         "GMAIL_APP_PASSWORD": "<YOUR GOOGLE APP PASSWORD>"
       },
       "transportType": "stdio"


### PR DESCRIPTION
## Summary
- make cline sample config use `<YOUR_GMAIL_ADDRESS>` like README

## Testing
- `python3 -m py_compile gmail_mcp_server.py`


------
https://chatgpt.com/codex/tasks/task_e_686bbed0058883259337c10bb82ddf8c